### PR TITLE
CMSPLT-61 Ability for attachments to upload to S3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 
     <properties>
         <!-- Dependency versions -->
+        <aws.version>1.10.65</aws.version>
         <c3p0.version>0.9.5-pre8</c3p0.version>
         <commons-fileupload.version>1.2.2</commons-fileupload.version>
         <commons-io.version>2.4</commons-io.version>
@@ -56,6 +57,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk</artifactId>
+                <version>${aws.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.mchange</groupId>
                 <artifactId>c3p0</artifactId>
@@ -278,6 +284,10 @@
 
     <dependencies>
         <!-- ===== Compile Time Dependencies ============================== -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.mchange</groupId>
             <artifactId>c3p0</artifactId>
@@ -651,14 +661,14 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!-- Provided jars don't seem to be added to the runtime
                                      classpath, so we manually add in servlet.jar here  -->
-                                <!--<property name="servlet.jar" value="${maven.dependency.javax.servlet.servlet-api.jar.path}" />-->
+                                <property name="servlet.jar" value="${maven.dependency.javax.servlet.servlet-api.jar.path}" />
 
                                 <java failonerror="true" fork="true" classname="org.jasig.portlet.attachment.util.ImportExport">
                                     <sysproperty key="logback.configurationFile" value="command-line.logback.xml" />
                                     <classpath>
                                         <pathelement path="${runtime_classpath}" />
                                         <pathelement path="${plugin_classpath}" />
-                                        <!--<pathelement location="${servlet.jar}" />-->
+                                        <pathelement location="${servlet.jar}" />
                                         <!--<pathelement path="${project.build.directory}/${project.artifactId}/WEB-INF/classes" />-->
                                     </classpath>
 
@@ -685,14 +695,14 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!-- Provided jars don't seem to be added to the runtime
                                      classpath, so we manually add in servlet.jar here  -->
-                                <!--<property name="servlet.jar" value="${maven.dependency.javax.servlet.servlet-api.jar.path}" />-->
+                                <property name="servlet.jar" value="${maven.dependency.javax.servlet.servlet-api.jar.path}" />
 
                                 <java failonerror="true" fork="true" classname="org.jasig.portlet.attachment.util.ImportExport">
                                     <sysproperty key="logback.configurationFile" value="command-line.logback.xml" />
                                     <classpath>
                                         <pathelement path="${runtime_classpath}" />
                                         <pathelement path="${plugin_classpath}" />
-                                        <!--<pathelement location="${servlet.jar}" />-->
+                                        <pathelement location="${servlet.jar}" />
                                         <!--<pathelement path="${project.build.directory}/${project.artifactId}/WEB-INF/classes" />-->
                                     </classpath>
 

--- a/src/main/java/org/jasig/portlet/attachment/model/Attachment.java
+++ b/src/main/java/org/jasig/portlet/attachment/model/Attachment.java
@@ -96,7 +96,10 @@ public class Attachment {
     @Column(name="BDATA",nullable=true,length=Integer.MAX_VALUE)
     private byte[] data;
 
-    @Column(name = "CHECKSUM", nullable=false, length=64)
+    /**
+     * Checksum as 32-digit hex value
+     */
+    @Column(name = "CHECKSUM", nullable=false, length=32)
     private String checksum;
 
     @Column(name = "CREATED_BY", nullable=false, length=128)
@@ -112,6 +115,18 @@ public class Attachment {
     @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "MODIFIED_AT", nullable=false)
     private Date modifiedAt;
+
+    /**
+     * Mime content type. Typically not needed unless persisting the attachment to S3 since most web
+     * servers will return a content type based on the filename extension, and value not needed for
+     * attachments maintenance. Field is made nullable since pre-2.0.3 it did not exist.  Data import of
+     * a data export will populate the field's value on old data since data import guesses at content type
+     * based on file extension.
+     *
+     * @since 2.0.3
+     */
+    @Column(name = "CONTENT_TYPE", nullable = true, length=128)
+    private String contentType;
 
     public Attachment()
     {
@@ -205,5 +220,13 @@ public class Attachment {
 
     public void setModifiedAt(Date modifiedAt) {
         this.modifiedAt = modifiedAt;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
     }
 }

--- a/src/main/java/org/jasig/portlet/attachment/service/AmazonS3PersistenceStrategy.java
+++ b/src/main/java/org/jasig/portlet/attachment/service/AmazonS3PersistenceStrategy.java
@@ -1,0 +1,152 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portlet.attachment.service;
+
+import java.io.ByteArrayInputStream;
+import java.text.MessageFormat;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.xml.bind.DatatypeConverter;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import org.apache.commons.codec.binary.Base64;
+import org.jasig.portlet.attachment.model.Attachment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Persistence strategy which persists the attachment's file to an S3 bucket
+ *
+ * @author James Wennmacher, jwennmacher@unicon.net
+ */
+@Service
+public class AmazonS3PersistenceStrategy implements IDocumentPersistenceStrategy {
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    private static final MessageFormat PATH_FORMAT = new MessageFormat("{0}/{1}/{2}");
+
+    @Value("${attachments.s3.bucket.name}")
+    String s3BucketName;
+
+    @Value("${attachments.s3.bucket.base.url}")
+    String s3BucketBaseUrl;
+
+    @Value("${attachments.s3.bucket.path:portlets/attachments}")
+    String s3BucketPath;
+
+    @Value("${attachments.s3.cache.control:private, max-age=2592000}")
+    String s3CacheControlString;
+
+    // By default, don't store file data into the database since S3 is an external location independent
+    // of the portal server.
+    boolean persistenceIntoDatabaseRequired = false;
+
+    @Override
+    public String persistAttachmentBinary(HttpServletRequest request, Attachment attachment)
+            throws PersistenceException {
+
+        // If doing a data import operation and there is no data in the attachment, there is nothing to save to S3.
+        // The data import is only going to update the attachment metadata in the database.
+        if (request == null && attachment.getData() == null ) {
+            return null;
+        }
+
+        AmazonS3 s3 = new AmazonS3Client();
+
+        String key = PATH_FORMAT.format(new Object[]{s3BucketPath, attachment.getGuid(), attachment.getFilename()});
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(attachment.getContentType());
+        metadata.setContentLength(attachment.getData().length);
+        metadata.setCacheControl(s3CacheControlString);
+
+        // S3 chose base64-encoded hash not the typical 32-character hex string so convert accordingly.
+        // Hex.decodeHex(attachment.getChecksum().toCharArray())
+        metadata.setContentMD5(Base64.encodeBase64String(DatatypeConverter.parseHexBinary(attachment.getChecksum())));
+
+        try {
+            s3.putObject(new PutObjectRequest(s3BucketName, key,
+                    new ByteArrayInputStream(attachment.getData()), metadata));
+            log.debug("Successfully sent {} to S3 bucket {} under key {}", attachment.getFilename(),
+                    s3BucketName, key);
+        } catch (AmazonClientException e) {
+            String message = String.format("Unable to persist attachment %1s to S3 bucket %2s, key %3s",
+                    attachment.getFilename(), s3BucketName, key);
+            throw new PersistenceException(message, e);
+        }
+
+        return (s3BucketBaseUrl.endsWith("/")? s3BucketBaseUrl : s3BucketBaseUrl + "/") + key;
+    }
+
+
+
+    /**
+     * Boolean indicating whether or not to store the file data into the database.  Storage into S3
+     * has the data external to the portal server in a stable persistent location so there is no need to have the
+     * file data stored into a database.
+     *
+     * @return True to store the file data in the database, else false.
+     */
+    public void setPersistenceIntoDatabaseRequired(boolean persistenceIntoDatabaseRequired) {
+        this.persistenceIntoDatabaseRequired = persistenceIntoDatabaseRequired;
+    }
+
+    @Override
+    public boolean isPersistenceIntoDatabaseRequired() {
+        return persistenceIntoDatabaseRequired;
+    }
+
+    public String getS3BucketName() {
+        return s3BucketName;
+    }
+
+    public void setS3BucketName(String s3BucketName) {
+        this.s3BucketName = s3BucketName;
+    }
+
+    public String getS3BucketBaseUrl() {
+        return s3BucketBaseUrl;
+    }
+
+    public void setS3BucketBaseUrl(String s3BucketBaseUrl) {
+        this.s3BucketBaseUrl = s3BucketBaseUrl;
+    }
+
+    public String getS3BucketPath() {
+        return s3BucketPath;
+    }
+
+    public void setS3BucketPath(String s3BucketPath) {
+        this.s3BucketPath = s3BucketPath;
+    }
+
+    public String getS3CacheControlString() {
+        return s3CacheControlString;
+    }
+
+    public void setS3CacheControlString(String s3CacheControlString) {
+        this.s3CacheControlString = s3CacheControlString;
+    }
+}

--- a/src/main/java/org/jasig/portlet/attachment/service/FileSystemPersistenceStrategy.java
+++ b/src/main/java/org/jasig/portlet/attachment/service/FileSystemPersistenceStrategy.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portlet.attachment.service;
+
+import java.io.IOException;
+import java.text.MessageFormat;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.jasig.portlet.attachment.model.Attachment;
+import org.jasig.portlet.attachment.util.FileUtil;
+import org.springframework.stereotype.Service;
+
+/**
+ * Persistence strategy which persists the attachment's file to the local filesystem.
+ *
+ * TODO Enhance to allow specifying a network share location.  Currently file storage is always
+ * on the local file system relative to webapp directory.
+ *
+ * @author James Wennmacher, jwennmacher@unicon.net
+ */
+
+@Service
+public class FileSystemPersistenceStrategy implements IDocumentPersistenceStrategy {
+
+    private static final String RELATIVE_ROOT = "/content";
+    private static final MessageFormat PATH_FORMAT = new MessageFormat(RELATIVE_ROOT + "/{0}/{1}");
+
+    @Override
+    public String persistAttachmentBinary(HttpServletRequest request, Attachment attachment)
+            throws PersistenceException {
+
+        // Data import operation. Don't save file to local file system.
+        if (request == null) {
+            return null;
+        }
+
+        String path = getAttachmentAbsolutePath(attachment, request);
+        try {
+            FileUtil.write(path, attachment.getData());
+        } catch (IOException e) {
+            throw new PersistenceException("Unable to persist file " + attachment.getFilename()
+                + "to path " + path, e);
+        }
+
+        final String context = request.getContextPath();
+        final String urlPath = context + PATH_FORMAT.format(new Object[]{ attachment.getGuid(),attachment.getFilename()});
+        return urlPath;
+    }
+
+    private String getAttachmentAbsolutePath(Attachment attachment, HttpServletRequest req) {
+        String relative = PATH_FORMAT.format(new Object[]{attachment.getGuid(), attachment.getFilename()});
+        String path = req.getSession().getServletContext().getRealPath(relative);
+        return path;
+    }
+
+    @Override
+    public boolean isPersistenceIntoDatabaseRequired() {
+        return true;
+    }
+}

--- a/src/main/java/org/jasig/portlet/attachment/service/IDocumentPersistenceStrategy.java
+++ b/src/main/java/org/jasig/portlet/attachment/service/IDocumentPersistenceStrategy.java
@@ -6,9 +6,9 @@
  * Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License.  You may obtain a
  * copy of the License at the following location:
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,33 +18,27 @@
  */
 package org.jasig.portlet.attachment.service;
 
-import java.util.List;
-
 import javax.servlet.http.HttpServletRequest;
 
 import org.jasig.portlet.attachment.model.Attachment;
 
 /**
- * @author Chris Waymire (chris@waymire.net)
+ * Defines persistence strategies for Attachment binary data.
+ *
+ * @author James Wennmacher, jwennmacher@unicon.net
  */
-public interface IAttachmentService {
-    Attachment get(long attachmentId);
-    Attachment get(String guid);
-    List<Attachment> find(String creator);
-    List<Attachment> find(String creator, String filename);
-    List<Attachment> findAll(int offset, int maxresults);
+
+public interface IDocumentPersistenceStrategy {
 
     /**
-     * Saves the metadata about the attachment to the database and persists the attachment to the
-     * configured documentPersistenceStrategy store.
-     * @param attachment  Attachment to persist
-     * @param username username of the user uploading the document
-     * @param request HttpServlet request.  Will be null with a data import operation
-     * @return Updated attachment object
+     * Accepts an attachment to save and persists the attachment binary data using the implemented persistence strategy.
+     *
+     * @param request HTTPServletRequest.  May be null to indicate a data import operation.
+     * @param attachment attachment containing data to save
+     * @return URL to access the attachment with.  Null means did not persist the attachment.
+     * @throws PersistenceException Exception persisting the document to the persistence store
      */
-    Attachment save(Attachment attachment, String username, HttpServletRequest request);
-    void delete(Attachment attachment);
-    void delete(long attachmentId);
+    String persistAttachmentBinary(HttpServletRequest request, Attachment attachment) throws PersistenceException;
 
     /**
      * Boolean indicating whether or not attachment data is stored into the database.  Some persistence stores,

--- a/src/main/java/org/jasig/portlet/attachment/service/PersistenceException.java
+++ b/src/main/java/org/jasig/portlet/attachment/service/PersistenceException.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portlet.attachment.service;
+
+/**
+ * Exception persisting documents to the persistence store
+ *
+ * @author James Wennmacher, jwennmacher@unicon.net
+ */
+
+public class PersistenceException extends RuntimeException {
+    public PersistenceException() {
+    }
+
+    public PersistenceException(String message) {
+        super(message);
+    }
+
+    public PersistenceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PersistenceException(Throwable cause) {
+        super(cause);
+    }
+
+    public PersistenceException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/org/jasig/portlet/attachment/service/impl/AttachmentService.java
+++ b/src/main/java/org/jasig/portlet/attachment/service/impl/AttachmentService.java
@@ -21,11 +21,15 @@ package org.jasig.portlet.attachment.service.impl;
 import java.util.Date;
 import java.util.List;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.commons.lang.StringUtils;
 import org.jasig.portlet.attachment.dao.IAttachmentDao;
+import org.jasig.portlet.attachment.service.IDocumentPersistenceStrategy;
 import org.jasig.portlet.attachment.model.Attachment;
 import org.jasig.portlet.attachment.service.IAttachmentService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 /**
@@ -36,31 +40,53 @@ public class AttachmentService implements IAttachmentService {
     @Autowired
     private IAttachmentDao attachmentDao;
 
+    @Autowired
+    @Qualifier(value = "documentPersistenceStrategy")
+    private IDocumentPersistenceStrategy documentPersistenceStrategy;
+
+    @Override
     public Attachment get(final long attachmentId) {
         return attachmentDao.get(attachmentId);
     }
 
+    @Override
     public Attachment get(final String guid) {
         return attachmentDao.get(guid);
     }
 
+    @Override
     public List<Attachment> find(final String creator) {
         return attachmentDao.find(creator);
     }
 
+    @Override
     public List<Attachment> find(final String creator,final String filename) {
         return attachmentDao.find(creator,filename);
     }
 
+    @Override
     public List<Attachment> findAll(int offset, int maxresults) {
         return attachmentDao.findAll(offset, maxresults);
     }
 
-    public Attachment save(Attachment attachment, String username) {
+    @Override
+    public Attachment save(Attachment attachment, String username, HttpServletRequest request) {
         // The username must be present
         if (StringUtils.isBlank(username)) {
             throw new IllegalArgumentException("Value for username cannot be blank;  " +
                     "is Tomcat's session path configured for shared sessions?");
+        }
+        String urlPath = documentPersistenceStrategy.persistAttachmentBinary(request, attachment);
+        // If document was persisted (might not be with data import operation), update the attachment's path.
+        if (urlPath != null) {
+            attachment.setPath(urlPath);
+        }
+
+        // If the documentPersistenceStrategy indicates document does not need to be stored in the database,
+        // null it out before persisting it so we don't waste space.  This can happen if the document is
+        // persisted to an URL-accessible common external store, such as S3.
+        if (!documentPersistenceStrategy.isPersistenceIntoDatabaseRequired()) {
+            attachment.setData(null);
         }
 
         Attachment existing = attachmentDao.get(attachment.getGuid());
@@ -68,8 +94,12 @@ public class AttachmentService implements IAttachmentService {
         {
             existing.setFilename(attachment.getFilename());
             existing.setPath(attachment.getPath());
-            existing.setData(attachment.getData());
+            if (documentPersistenceStrategy.isPersistenceIntoDatabaseRequired()) {
+                existing.setData(attachment.getData());
+            }
+            existing.setChecksum(attachment.getChecksum());
             existing.setSource(attachment.getSource());
+            existing.setContentType(attachment.getContentType());
             attachment = existing;
         }
 
@@ -78,10 +108,12 @@ public class AttachmentService implements IAttachmentService {
         return saved;
     }
 
+    @Override
     public void delete(Attachment attachment) {
         attachmentDao.delete(attachment);
     }
 
+    @Override
     public void delete(long attachmentId) {
         attachmentDao.delete(attachmentId);
     }
@@ -98,4 +130,24 @@ public class AttachmentService implements IAttachmentService {
         attachment.setModifiedAt(now);
     }
 
+    public IAttachmentDao getAttachmentDao() {
+        return attachmentDao;
+    }
+
+    public void setAttachmentDao(IAttachmentDao attachmentDao) {
+        this.attachmentDao = attachmentDao;
+    }
+
+    public IDocumentPersistenceStrategy getDocumentPersistenceStrategy() {
+        return documentPersistenceStrategy;
+    }
+
+    public void setDocumentPersistenceStrategy(IDocumentPersistenceStrategy documentPersistenceStrategy) {
+        this.documentPersistenceStrategy = documentPersistenceStrategy;
+    }
+
+    @Override
+    public boolean isPersistenceIntoDatabaseRequired() {
+        return documentPersistenceStrategy.isPersistenceIntoDatabaseRequired();
+    }
 }

--- a/src/main/resources/configuration.properties
+++ b/src/main/resources/configuration.properties
@@ -1,0 +1,39 @@
+# IDocumentPersistenceStrategy bean name to use for saving attachments.  Possible values are
+# - fileSystemPersistenceStrategy
+# - amazonS3PersistenceStrategy
+attachment.document.persistence.bean=fileSystemPersistenceStrategy
+
+##
+## S3 Storage Persistence Configuration for Attachments Data
+##
+
+# Amazon Credentials:
+# Amazon EC2 instances: Configure your EC2 instances to have a role that provides access to the appropriate bucket
+# For local development and testing, store your AWS secret key and access key in ~/.aws/credentials
+# (C:\Users\USER_NAME\.aws\credentials for Windows users).
+
+# NOTE: Since uploading a new file (from SimpleContentPortlet or other locations) currently ALWAYS creates
+# a new object, with S3 you could end up with storing a bunch of data that you pay monthly for and you
+# don't have an easy way to tell if the objects stored are still being used or just costing you money
+# for storage every month.  This same inefficiency exists when storing to the local file system but it
+# is less significant since deploying a new version of the SimpleContentPortlet webapp wipes out
+# the local storage location.
+#
+# In practice the portal typically doesn't have a large number of items uploaded (and hopefully not very many
+# large items) so this concern is being deferred as not significant at the moment.  If it becomes an issue
+# it will need to be dealt with.  You can always enable access logging on your S3 bucket and process those
+# logs to determine if artifacts no longer receive accesses.
+
+# S3 bucket name to save attachments to; e.g. portal-webresources.  Configure the S3 bucket for
+# Website Hosting.  Configure bucket access rights accordingly (e.g. public access, etc.).
+attachments.s3.bucket.name=
+# URL to get to above-named bucket; e.g. https://portal-webresources.s3.amazonaws.com
+attachments.s3.bucket.base.url=
+# Path within bucket to store the attachments. URL to access resource will be
+# <attachments.s3.bucket.base.url>/<attachments.s3.bucket.path>/<guid>/<filename.ext>
+attachments.s3.bucket.path=portlets/attachments
+# Duration in seconds for attachments to be cached by the browser. 2592000=60*60*24*30
+attachments.s3.cache.control=private, max-age=2592000
+
+
+

--- a/src/main/resources/context/baseContext.xml
+++ b/src/main/resources/context/baseContext.xml
@@ -31,10 +31,14 @@
     <context:component-scan base-package="org.jasig.portlet.attachment.dao"/>
     <context:component-scan base-package="org.jasig.portlet.attachment.service"/>
 
+    <!-- Configured document persistence strategy to use for attachments. -->
+    <alias alias="documentPersistenceStrategy" name="${attachment.document.persistence.bean}"/>
+
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="locations">
             <list>
                 <value>classpath:hibernate.properties</value>
+                <value>classpath:configuration.properties</value>
                 <!--
                  |  The following files optionally allow deployers to set or override many uPortal
                  |  configuration settings in a outside the control of the build/deploy cycle, SCM,

--- a/src/main/resources/context/portlet/attachments.xml
+++ b/src/main/resources/context/portlet/attachments.xml
@@ -27,7 +27,6 @@
                         http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
                         http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-
     <context:component-scan base-package="org.jasig.portlet.attachment.controller">
     </context:component-scan>
 

--- a/src/main/resources/hibernate.properties
+++ b/src/main/resources/hibernate.properties
@@ -20,7 +20,7 @@
 ## Default configuration uses an in-memory database that will reset 
 ## whenever you restart the portlet
 hibernate.connection.driver_class=org.hsqldb.jdbc.JDBCDriver
-hibernate.connection.url=jdbc:hsqldb:mem:simplecontent
+hibernate.connection.url=jdbc:hsqldb:hsql://localhost:8887/uPortal
 hibernate.connection.username=sa
 hibernate.connection.password=
 hibernate.dialect=org.hibernate.dialect.HSQLDialect


### PR DESCRIPTION
Ability to configure SCP to have attachments binary stored on S3 instead of in the database and reconstituted onto the local file system.  This capability is useful if you want to externalize your attachments for public or restricted access.  The document metadata is still stored in the SCP database.  Default behavior is the previous behavior.

The Amazon implementation of the pluggable Document Persistence Strategy returns an Amazon URL for the attachment so the portal is not accessed to obtain the document.

Includes support of import and export capability for documents.  Data in import XML documents is written to Amazon S3.

Existing code supports overrides.properties strategy so you can have environment-specific S3 buckets.