### PR TITLE
CMSPLT-70:  Drop the hibernate3-maven-plugin in favor of providing di…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,12 @@
                 <artifactId>hibernate-ehcache</artifactId>
                 <version>${hibernate.version}</version>
             </dependency>
+            <!-- Needed for schema reset;  version compatible with org.hibernate:hibernate-core:4.1.9.Final -->
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-tools</artifactId>
+                <version>4.0.0.Final</version>
+            </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>jstl</artifactId>
@@ -320,6 +326,10 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-jpamodelgen</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-tools</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hibernate.javax.persistence</groupId>
@@ -632,34 +642,47 @@
                 <!-- extensions must be set to true to pick up the custom phases -->
                 <extensions>true</extensions>
             </plugin>
+            <!--
+             | Invoke this plugin as follows to drop and recreate the Announcements database tables...
+             |
+             |   >mvn db-init
+             +-->
             <plugin>
-                <!--
-                 | Invoke this plugin as follows to drop and recreate the database tables...
-                 |
-                 |   >mvn db-init
-                 +-->
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>hibernate3-maven-plugin</artifactId>
-                <version>2.2</version>
+                <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>schema-create</id>
                         <phase>db-init</phase>
                         <goals>
-                            <goal>hbm2ddl</goal>
+                            <goal>run</goal>
                         </goals>
+                        <configuration>
+                            <tasks>
+                                <property name="runtime_classpath" refid="maven.runtime.classpath" />
+                                <property name="plugin_classpath" refid="maven.plugin.classpath" />
+
+                                <java failonerror="true" classname="org.jasig.portlet.attachment.util.SchemaCreator">
+                                    <sysproperty key="logback.configurationFile" value="command-line.logback.xml" />
+                                    <classpath>
+                                        <pathelement location="${project.build.directory}/${project.artifactId}/WEB-INF/context" />
+                                        <pathelement path="${runtime_classpath}" />
+                                        <pathelement path="${plugin_classpath}" />
+                                    </classpath>
+                                </java>
+                            </tasks>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <componentProperties>
-                        <drop>true</drop>
-                    </componentProperties>
-                </configuration>
                 <dependencies>
                     <dependency>
-                        <groupId>${jdbc.groupId}</groupId>
-                        <artifactId>${jdbc.artifactId}</artifactId>
-                        <version>${jdbc.version}</version>
-                        <scope>compile</scope>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>servlet-api</artifactId>
+                        <version>2.5</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>javax.portlet</groupId>
+                        <artifactId>portlet-api</artifactId>
+                        <version>2.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/src/main/java/org/jasig/portlet/attachment/util/SchemaCreator.java
+++ b/src/main/java/org/jasig/portlet/attachment/util/SchemaCreator.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to Apereo under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright ownership. Apereo
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the License at the
+ * following location:
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jasig.portlet.attachment.util;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.apache.log4j.Logger;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.jasig.portlet.attachment.model.Attachment;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.io.Resource;
+
+/**
+ * This tool is responsible for creating the SimpleCMS portlet database schema (and dropping
+ * it first, if necessary).  It leverages the org.hibernate:hibernate-tools library, but integrates
+ * with SimpleCMS' Spring-managed ORM strategy and SimpleCMS' configuration features (esp.
+ * encrypted properties).  It is invokable from the command line with '$ java', but designed to be
+ * integrated with build tools like Gradle.
+ */
+public class SchemaCreator implements ApplicationContextAware {
+
+    private static final String APPLICATION_CONTEXT_LOCATION = "classpath:/context/baseContext.xml";
+
+    private static final String DATA_SOURCE_BEAN_NAME = "dataSource";
+
+    private ApplicationContext applicationContext;
+
+    private final Logger logger = Logger.getLogger(getClass());
+
+    public static void main(String[] args) {
+
+        // Bootstrap an ApplicationContext...
+        final GenericApplicationContext context = new GenericApplicationContext();
+        final XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(context);
+
+        final Resource resource = context.getResource(APPLICATION_CONTEXT_LOCATION);
+        reader.loadBeanDefinitions(resource);
+
+        context.refresh();
+        context.registerShutdownHook(); // close this context on JVM shutdown unless it has already been closed.
+
+        final SchemaCreator schemaCreator = context.getBean("schemaCreator", SchemaCreator.class);
+        System.exit(schemaCreator.create());
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    private int create() {
+
+        /*
+         * We will need to provide a Configuration and a Connection;  both should be properly
+         * managed by the Spring ApplicationContext.
+         */
+
+        final DataSource dataSource = applicationContext.getBean(DATA_SOURCE_BEAN_NAME, DataSource.class);
+
+        try (final Connection conn = dataSource.getConnection()) {
+
+            Configuration config = new Configuration();
+            config.addAnnotatedClass(Attachment.class);
+
+            final SchemaExport schemaExport = new SchemaExport(config, conn);
+            schemaExport.execute(true, true, false, false);
+
+            final List<Exception> exceptions = schemaExport.getExceptions();
+            if (exceptions.size() != 0) {
+                logger.error("Schema Create Failed;  see below for details");
+                for (Exception e : exceptions) {
+                    logger.error("Exception from Hibernate Tools SchemaExport", e);
+                }
+                return 1;
+            }
+        } catch (SQLException sqle) {
+            logger.error("Failed to initialize & invoke the SchemaExport tool", sqle);
+            return 1;
+        }
+
+        return 0;
+
+    }
+
+}

--- a/src/main/resources/context/baseContext.xml
+++ b/src/main/resources/context/baseContext.xml
@@ -124,4 +124,7 @@
 
     <tx:annotation-driven transaction-manager="transactionManager" proxy-target-class="true"/>
 
+    <!-- Used to [drop and] create the Attachments database schema from the command line -->
+    <bean id="schemaCreator" class="org.jasig.portlet.attachment.util.SchemaCreator" />
+
 </beans>


### PR DESCRIPTION
…rect support for database schema drop+create

https://issues.jasig.org/browse/CMSPLT-70

The Simple CMS portlet implements a 'db-init' Maven goal that drops & re-creates the database schema.  This capability is integrated into the uP4 Maven build via uportal-portlets-overlay.

The current implementation is based on the hibernate3-maven-plugin.  This solution is problematic because (1) it's not well integrated into the rest of the app's features (so it's always been very brittle), and (2) it doesn't port well to the Gradle-based build in uP5.

We need to  replace it with something we provide directly that *is* a first-class part of the Spring app.