### PR TITLE
fix:  SimpleCMS portlet in CONFIG mode improperly uses a portlet:acti…

### DIFF
--- a/src/main/java/org/jasig/portlet/cms/mvc/portlet/ConfigureContentController.java
+++ b/src/main/java/org/jasig/portlet/cms/mvc/portlet/ConfigureContentController.java
@@ -19,7 +19,6 @@
 package org.jasig.portlet.cms.mvc.portlet;
 
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 import javax.portlet.ActionRequest;
@@ -36,7 +35,6 @@ import org.jasig.portlet.cms.service.IStringCleaningService;
 import org.jasig.portlet.cms.service.dao.IContentDao;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -112,21 +110,7 @@ public class ConfigureContentController {
         // exit the portlet's configuration mode
         response.setPortletMode(PortletMode.VIEW);
     }
-    
-    /**
-     * Cancel any pending portlet configuration edits and exit configuration mode.
-     * 
-     * @param request ActionRequest
-     * @param response ActionResponse
-     * @throws PortletModeException exception
-     */
-    @RequestMapping(params="action=cancelUpdate")
-    public void cancelUpdate(ActionRequest request, ActionResponse response) 
-            throws PortletModeException {
-        // exit the portlet's configuration mode
-        response.setPortletMode(PortletMode.VIEW);
-    }
-    
+
     @ResourceMapping("preview")
     public ModelAndView getPreview(@RequestParam("content") String content) {
         
@@ -168,26 +152,5 @@ public class ConfigureContentController {
         PortletPreferences preferences = request.getPreferences();
         return Boolean.valueOf(preferences.getValue("cleanContent", "true"));
     }
-    
-    /**
-     * Get the list of supported locales to populate the drop-down list with.
-     * 
-     * @param request PortletRequest
-     * @return list of supported locals
-     */
-//    @ModelAttribute("supportedLocales")
-    public HashMap<String, String> getLocales(PortletRequest request) {
 
-        PortletPreferences preferences = request.getPreferences();
-        String[] supportedLocales = preferences.getValues("supportedLocales", new String[]{});
-        HashMap<String, String> locales = new HashMap<String, String>(); 
-
-        for (String localeString : supportedLocales) {
-            localeString = localeString.trim();
-            Locale locale = StringUtils.parseLocaleString(localeString.trim());
-            locales.put(localeString.trim(), localeString.trim() + ": " + locale.getDisplayName());
-        }
-
-        return locales;
-    }
 }

--- a/src/main/webapp/WEB-INF/jsp/configureContent.jsp
+++ b/src/main/webapp/WEB-INF/jsp/configureContent.jsp
@@ -22,7 +22,7 @@
 <c:set var="includeJQuery" value="${renderRequest.preferences.map['includeJQuery'][0]}"/>
 <c:set var="n"><portlet:namespace/></c:set>
 <portlet:actionURL var="formUrl" escapeXml="false"><portlet:param name="action" value="updateConfiguration"/></portlet:actionURL>
-<portlet:actionURL var="cancelUrl"><portlet:param name="action" value="cancelUpdate"/></portlet:actionURL>
+<portlet:renderURL var="cancelUrl" portletMode="VIEW" />
 <%--<portlet:resourceURL var="previewUrl" id="preview" escapeXml="false"/>--%>
 
 <c:if test="${includeJQuery}">

--- a/src/test/java/org/jasig/portlet/cms/mvc/portlet/ConfigureContentControllerTest.java
+++ b/src/test/java/org/jasig/portlet/cms/mvc/portlet/ConfigureContentControllerTest.java
@@ -74,12 +74,6 @@ public class ConfigureContentControllerTest {
     }
     
     @Test
-    public void testCancelUpdate() throws PortletModeException {
-        controller.cancelUpdate(request, response);
-        verify(response).setPortletMode(PortletMode.VIEW);
-    }
-
-    @Test
     public void testUpdateConfiguration() throws ReadOnlyException, PortletModeException {
         
         ContentForm form = new ContentForm();


### PR DESCRIPTION
…onURL with an HTTP GET

This PR fixes another one of those HTTP "method mismatches" where a `portlet:actionURL` is used with a GET request (or vice versa).