### PR TITLE
chore(log4j): remove log4j dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,12 +295,6 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>1.2.17</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>


### PR DESCRIPTION
"vulnerability" fix where this is not used when running, but still causing an alert in CI.