### PR TITLE
feat(propertyResolver): add support for replacing tokens with properties

### DIFF
--- a/src/main/java/org/jasig/portlet/cms/mvc/portlet/ViewContentController.java
+++ b/src/main/java/org/jasig/portlet/cms/mvc/portlet/ViewContentController.java
@@ -24,6 +24,7 @@ import javax.portlet.PortletRequest;
 
 import org.jasig.portlet.cms.service.dao.IContentDao;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.PropertyResolver;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,14 +38,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Controller
 @RequestMapping("VIEW")
 public class ViewContentController {
-    
-    private IContentDao contentDao;
-    
+
     @Autowired
-    public void setContentDao(IContentDao contentDao) {
-        this.contentDao = contentDao;
-    }
-    
+    private PropertyResolver propertyResolver;
+
+    @Autowired
+    private IContentDao contentDao;
+
     /**
      * Display the main user-facing view of the portlet.
      * 
@@ -64,7 +64,6 @@ public class ViewContentController {
     @ModelAttribute("content")
     public String getContent(PortletRequest request){
         Locale locale = request.getLocale();
-        return this.contentDao.getContent(request, locale.toString());
+        return propertyResolver.resolvePlaceholders(contentDao.getContent(request, locale.toString()));
     }
-    
 }

--- a/src/main/resources/context/baseContext.xml
+++ b/src/main/resources/context/baseContext.xml
@@ -73,6 +73,8 @@
         </property>
     </bean>
 
+    <bean id="propertyResolver" factory-bean="propertyConfigurer" factory-method="getPropertyResolver"/>
+
     <bean id="dataSource" class="com.mchange.v2.c3p0.ComboPooledDataSource" destroy-method="close"
           p:driverClass="${hibernate.connection.driver_class}"
           p:jdbcUrl="${hibernate.connection.url}"

--- a/src/main/resources/context/portlet/cms.xml
+++ b/src/main/resources/context/portlet/cms.xml
@@ -30,7 +30,7 @@
     <context:component-scan base-package="org.jasig.portlet.cms.mvc.portlet"/>
     <context:annotation-config/>
 
-    <bean parent="propertyConfigurer"/>
+    <bean parent="propertyResolver"/>
 
     <bean class="org.springframework.web.portlet.mvc.annotation.DefaultAnnotationHandlerMapping">
         <property name="interceptors"><bean class="org.jasig.portlet.cms.mvc.portlet.MinimizedStateHandlerInterceptor"/></property>

--- a/src/test/java/org/jasig/portlet/cms/mvc/portlet/ViewContentControllerTest.java
+++ b/src/test/java/org/jasig/portlet/cms/mvc/portlet/ViewContentControllerTest.java
@@ -27,23 +27,29 @@ import javax.portlet.PortletRequest;
 import org.jasig.portlet.cms.service.dao.IContentDao;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.core.env.PropertyResolver;
 
 public class ViewContentControllerTest {
 
     @Mock PortletRequest request;
     @Mock IContentDao contentDao;
+    @Mock
+    PropertyResolver propertyResolver;
     
     String content = "<h1>Title</h1><p>content</p>";
+
+    @InjectMocks
     ViewContentController controller = new ViewContentController();
     
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         
-        controller.setContentDao(contentDao);
         when(contentDao.getContent(request, Locale.US.toString())).thenReturn(content);
+        when(propertyResolver.resolvePlaceholders(content)).thenReturn(content);
         when(request.getLocale()).thenReturn(Locale.US);
     }
     


### PR DESCRIPTION
For example, ${dog} would be replaced in CMS content with "Maddy" if "dog=Maddy" is in simple-cms.properties