### PR TITLE
chore: migrate jasig-parent → uportal-portlet-parent:46

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <parent>
-        <groupId>org.jasig.parent</groupId>
-        <artifactId>jasig-parent</artifactId>
-        <version>41</version>
+        <groupId>org.jasig.portlet</groupId>
+        <artifactId>uportal-portlet-parent</artifactId>
+        <version>46</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -87,6 +87,14 @@
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-s3</artifactId>
                 <version>${aws.version}</version>
+                <exclusions>
+                    <!-- aws-java-sdk-core pulls commons-logging:1.1.3
+                         (banned by uportal-portlet-parent, use jcl-over-slf4j). -->
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>
@@ -242,6 +250,19 @@
                 <groupId>org.owasp</groupId>
                 <artifactId>antisamy</artifactId>
                 <version>1.4</version>
+                <exclusions>
+                    <!-- antisamy 1.4 pulls commons-httpclient:3.1 which pulls
+                         commons-logging:1.0.4 (banned by uportal-portlet-parent,
+                         use jcl-over-slf4j). -->
+                    <exclusion>
+                        <groupId>commons-httpclient</groupId>
+                        <artifactId>commons-httpclient</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
@@ -672,8 +693,9 @@
                 </configuration>
             </plugin>
             <plugin>
+                <!-- Renamed from maven-notice-plugin; v2.0.0 inherited from uportal-portlet-parent works on Java 11. -->
                 <groupId>org.jasig.maven</groupId>
-                <artifactId>maven-notice-plugin</artifactId>
+                <artifactId>notice-maven-plugin</artifactId>
                 <configuration>
                     <noticeTemplate>NOTICE.template</noticeTemplate>
                 </configuration>


### PR DESCRIPTION
Consume the newly-released `uportal-portlet-parent:44` instead of the old `org.jasig.parent:jasig-parent:41`. One-line `<parent>` bump.

### What v44 brings

- Central Publisher Portal `<distributionManagement>` (replaces the dead `oss.sonatype.org` URLs that were sunset June 2025)
- `<developers>` block required for Central Portal validation
- Java 11 compiler default
- Drops the unmaintained `org.sonatype.oss:oss-parent:9` inheritance

Part of the ecosystem-wide sweep. Validated with `mvn help:effective-pom -N`.

Parent release: uPortal-Project/uportal-portlet-parent#7