### PR TITLE
chore: pin renovate constraints to portlet's supported versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,50 @@
 {
-  "extends": ["config:base", ":rebaseStalePrs", ":preserveSemverRanges"],
-  "renovateFork": true
+  "extends": [
+    "config:base",
+    ":rebaseStalePrs",
+    ":preserveSemverRanges"
+  ],
+  "renovateFork": true,
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "javax.portlet:portlet-api"
+      ],
+      "allowedVersions": "< 3.0",
+      "description": "uPortal runs JSR-286 (Portlet API 2.0). Portlet API 3.x (JSR-362) is a different container contract and is not supported."
+    },
+    {
+      "matchPackageNames": [
+        "org.springframework:spring-framework-bom",
+        "org.springframework:spring-aop",
+        "org.springframework:spring-beans",
+        "org.springframework:spring-context",
+        "org.springframework:spring-context-support",
+        "org.springframework:spring-core",
+        "org.springframework:spring-jdbc",
+        "org.springframework:spring-orm",
+        "org.springframework:spring-test",
+        "org.springframework:spring-tx",
+        "org.springframework:spring-web",
+        "org.springframework:spring-webmvc",
+        "org.springframework:spring-webmvc-portlet",
+        "org.springframework.data:spring-data-jpa"
+      ],
+      "allowedVersions": "< 6.0",
+      "description": "This portlet is pinned to Spring Framework 5.3.x. Next-major bumps require a coordinated migration."
+    },
+    {
+      "matchPackageNames": [
+        "org.hibernate:hibernate-core",
+        "org.hibernate:hibernate-ehcache",
+        "org.hibernate:hibernate-entitymanager",
+        "org.hibernate:hibernate-jpamodelgen",
+        "org.hibernate:hibernate-tools",
+        "org.hibernate:hibernate-validator",
+        "org.hibernate.orm:hibernate-core"
+      ],
+      "allowedVersions": "< 6.0",
+      "description": "Pinned to Hibernate 5.6.x. Later majors require Jakarta EE or Java 17+, neither of which match this portlet."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Add `packageRules` so Renovate stops proposing bumps that violate this portlet's pinning. Same pattern as [AnnouncementsPortlet#331](https://github.com/uPortal-Project/AnnouncementsPortlet/pull/331) and [basiclti-portlet#56](https://github.com/uPortal-Project/basiclti-portlet/pull/56), tailored to this portlet's actual pinned versions.

Rules:
- **`javax.portlet:portlet-api < 3.0`** — uPortal runs JSR-286 (Portlet API 2.0). v3.x is JSR-362, a different container contract.
- **Spring Framework + spring-data-jpa** — capped at this portlet's pinned line.
- **Hibernate (where used)** — capped. Later majors require Jakarta EE or Java 17+, neither of which match this stack.

Once merged, any existing Renovate/Dependabot PRs that violate these constraints should auto-close on their next rebase cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)