### PR TITLE
chore: drop local maven-compiler-plugin override + pin jakarta/hibernate-orm in renovate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -420,15 +420,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <dependencies>
                     <dependency>

--- a/renovate.json
+++ b/renovate.json
@@ -28,23 +28,28 @@
         "org.springframework:spring-web",
         "org.springframework:spring-webmvc",
         "org.springframework:spring-webmvc-portlet",
-        "org.springframework.data:spring-data-jpa"
+        "org.springframework.data:spring-data-jpa",
+        "com.liferay.portletmvc4spring:com.liferay.portletmvc4spring.framework",
+        "com.liferay.portletmvc4spring:com.liferay.portletmvc4spring.security"
       ],
       "allowedVersions": "< 6.0",
-      "description": "This portlet is pinned to Spring Framework 5.3.x. Next-major bumps require a coordinated migration."
+      "description": "This portlet is pinned to Spring Framework 5.3.x. Next-major bumps (Spring 6+) require Jakarta EE + Java 17+, neither of which match this portlet's stack."
+    },
+    {
+      "matchPackagePrefixes": [
+        "org.hibernate:",
+        "org.hibernate.orm:"
+      ],
+      "allowedVersions": "< 6.0",
+      "description": "Pinned to Hibernate 5.6.x. Hibernate 6+ (including the org.hibernate.orm groupId rename, hibernate-processor, hibernate-c3p0 relocations) requires Jakarta EE and Java 17+."
     },
     {
       "matchPackageNames": [
-        "org.hibernate:hibernate-core",
-        "org.hibernate:hibernate-ehcache",
-        "org.hibernate:hibernate-entitymanager",
-        "org.hibernate:hibernate-jpamodelgen",
-        "org.hibernate:hibernate-tools",
-        "org.hibernate:hibernate-validator",
-        "org.hibernate.orm:hibernate-core"
+        "jakarta.xml.bind:jakarta.xml.bind-api",
+        "org.glassfish.jaxb:jaxb-runtime"
       ],
-      "allowedVersions": "< 6.0",
-      "description": "Pinned to Hibernate 5.6.x. Later majors require Jakarta EE or Java 17+, neither of which match this portlet."
+      "allowedVersions": "< 3.0",
+      "description": "jakarta.xml.bind-api and jaxb-runtime 2.x are the last releases compatible with javax.xml.bind.* packages. 3.x+ moves to the jakarta.xml.bind package and is part of the broader Jakarta EE migration, which this portlet is not yet doing."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Two cleanups that together tidy up stale config and silence recurring Renovate noise.

### pom.xml — drop local maven-compiler-plugin override

The local block pinned `maven-compiler-plugin:3.10.1` with `source/target=1.8`. Both are stale:

| | Was | Now (from parent) |
|---|---|---|
| plugin version | 3.10.1 | 3.13.0 (parent pluginManagement) |
| `source` / `target` | 1.8 | 11 (parent default, matches CI) |

CI matrix already runs Java 11-only (#517); `target=1.8` was vestigial.

**Supersedes #501** (which was bumping the now-deleted block to 3.15.0).

### renovate.json — tighten rules

1. **Hibernate** — broaden from `matchPackageNames` to `matchPackagePrefixes: ["org.hibernate:", "org.hibernate.orm:"]`. Catches all the artifact-relocation bumps Renovate keeps generating (`hibernate-processor`, `hibernate-c3p0`, and the new `org.hibernate.orm` groupId variants). Blocks #520, #521, #512.
2. **Spring** — add the Liferay `portletmvc4spring` artifacts (they track Spring majors; v6 requires Spring 6).
3. **Jakarta XML Bind** — new rule pinning `jakarta.xml.bind:jakarta.xml.bind-api` and `org.glassfish.jaxb:jaxb-runtime` to `< 3.0`. The 2.x line is the last that preserves the `javax.xml.bind.*` package. 3+ moves to the `jakarta.xml.bind` package and belongs to a full Jakarta EE migration. Blocks #266.

## Test plan

- [x] `mvn help:effective-pom` confirms `maven-compiler-plugin:3.13.0` inherits from parent with source/target=11
- [x] `mvn compile` passes on Java 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)