### PR TITLE
chore: drop local mockito-core override, inherit parent 4.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.12.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary

Drop the local `<version>3.12.4</version>` override on `mockito-core` so this portlet inherits parent v48's pin (4.9.0). A meaningful 3 → 4 upgrade without the pitfalls of the 3 → 5 jump Renovate has been proposing.

### Why not Renovate #349 (bump to 5.23)?

Mockito 5 ships a byte-buddy that expects a newer internal API (`net.bytebuddy.ClassFileVersion.JAVA_V21`) than the byte-buddy pulled transitively through Hibernate/Javassist on this portlet's classpath. CI fails on `NoSuchFieldError: JAVA_V21` during MockMaker initialization. Resolving that would require either pinning `net.bytebuddy:byte-buddy` in our `dependencyManagement` or excluding the transitive copies — neither is clean.

### Why 4.9.0 works

- Mockito 4.9.0 ships byte-buddy 1.12.18, which is compatible with what the hibernate/javassist path pulls.
- Mockito 3 → 4 dropped Java 8 support (we're on Java 11+); no other behavior changes impact this portlet's test code.
- This portlet's tests don't use any API that 4.x removed (`verifyZeroInteractions`, `anyObject`, etc.).

Mockito 5 can happen later via a coordinated parent bump once the byte-buddy / hibernate classpath can be reconciled — better done once at parent level than per-portlet.

## Test plan

- [x] `mvn test` — 14 tests pass locally on Java 11 with mockito-core 4.9.0 (inherited)
- [x] `mvn dependency:tree` confirms `org.mockito:mockito-core:jar:4.9.0:test` resolves from parent dM

🤖 Generated with [Claude Code](https://claude.com/claude-code)