### PR TITLE
fix: drop plexus-archiver plugin-level override on maven-war-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -427,13 +427,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.codehaus.plexus</groupId>
-                        <artifactId>plexus-archiver</artifactId>
-                        <version>4.11.0</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
                     <warName>${project.artifactId}</warName>
                     <webXml>${basedir}/src/main/webapp/WEB-INF/web.xml</webXml>


### PR DESCRIPTION
## Summary

Master is broken: `mvn install` fails with

```
NoSuchMethodError: 'org.apache.commons.io.input.BoundedInputStream\$Builder
BoundedInputStream.builder()'
```

This PR fixes it by dropping the plugin-level `plexus-archiver` override on `maven-war-plugin`.

## Root cause

The override was added in May 2025 (cd7786b, "Build dep fixes") pinning `plexus-archiver:4.4.0` onto `maven-war-plugin:3.4.0`. Renovate has been bumping it ever since — most recently to **4.11.0** (PR #534).

`plexus-archiver:4.11.0` calls `org.apache.commons.io.input.BoundedInputStream.builder()`, which was added in **commons-io 2.16**. But `maven-war-plugin:3.4.0`'s plugin classpath ships **commons-io 2.13.0** (visible in the failure's classworlds dump). Plugin-level `<dependencies>` only inject the named artifact — they don't pull transitive deps the way project deps do — so the override forces a newer `plexus-archiver` onto an older I/O lib and Maven can't resolve the symbol at runtime.

## Fix

Drop the override. `maven-war-plugin:3.4.0` already bundles a compatible `plexus-archiver` (currently 4.10.x via `maven-archiver:3.6.0`), and we don't depend on any feature in the newer line that the bundled one lacks.

## Changes

`pom.xml`:
- Remove the `<dependencies>...<plexus-archiver:4.11.0>` block from the `maven-war-plugin` `<plugin>` declaration.
- Keep the plugin's `<configuration>` intact (warName, webXml, overlays, archive manifest entries).


## Test plan

- [x] `mvn clean install -Dgpg.skip=true` — green (was failing before this fix on master)
- [ ] CI on Java 11 matrix
- [ ] After merge: rebase #543 (license-plugin sweep) so its build verification can run cleanly

## Out of scope

If we ever need a specific `plexus-archiver` version again, re-pin it **together with** a matching `commons-io` override (and a `renovate.json` `packageRules` group that bumps them in lockstep) so Renovate doesn't separate them. Not needed for this fix.
