### PR TITLE
chore: bump parent v50 → v51 and migrate commons-lang → commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.jasig.portlet</groupId>
         <artifactId>uportal-portlet-parent</artifactId>
-        <version>50</version>
+        <version>51</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/src/main/java/org/jasig/portlet/attachment/mvc/LocalAttachmentController.java
+++ b/src/main/java/org/jasig/portlet/attachment/mvc/LocalAttachmentController.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.portlet.attachment.controller.AttachmentsController;
 import org.jasig.portlet.attachment.model.Attachment;
 import org.jasig.portlet.attachment.service.IAttachmentService;

--- a/src/main/java/org/jasig/portlet/attachment/service/impl/AttachmentService.java
+++ b/src/main/java/org/jasig/portlet/attachment/service/impl/AttachmentService.java
@@ -25,7 +25,7 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.transaction.Transactional;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.portlet.attachment.dao.jpa.AttachmentsRepository;
 import org.jasig.portlet.attachment.service.IDocumentPersistenceStrategy;
 import org.jasig.portlet.attachment.model.Attachment;

--- a/src/main/java/org/jasig/portlet/attachment/util/FileUtil.java
+++ b/src/main/java/org/jasig/portlet/attachment/util/FileUtil.java
@@ -32,7 +32,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/src/main/java/org/jasig/portlet/attachment/util/ImportExport.java
+++ b/src/main/java/org/jasig/portlet/attachment/util/ImportExport.java
@@ -38,7 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.portlet.attachment.model.Attachment;
 import org.jasig.portlet.attachment.service.IAttachmentService;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/org/jasig/portlet/cms/mvc/portlet/SearchContentController.java
+++ b/src/main/java/org/jasig/portlet/cms/mvc/portlet/SearchContentController.java
@@ -26,7 +26,7 @@ import javax.portlet.EventResponse;
 import javax.portlet.PortletRequest;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apereo.portal.search.SearchConstants;
 import org.apereo.portal.search.SearchRequest;
 import org.apereo.portal.search.SearchResult;

--- a/src/main/java/org/jasig/portlet/cms/service/dao/PortletPreferencesContentDaoImpl.java
+++ b/src/main/java/org/jasig/portlet/cms/service/dao/PortletPreferencesContentDaoImpl.java
@@ -26,7 +26,7 @@ import javax.portlet.PortletRequest;
 import javax.portlet.ReadOnlyException;
 import javax.portlet.ValidatorException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jasig.portlet.cms.mvc.exception.ContentPersistenceException;


### PR DESCRIPTION
Bumps to [uportal-portlet-parent:51](https://github.com/uPortal-Project/uportal-portlet-parent/releases/tag/uportal-portlet-parent-51), which closes [CVE-2025-48924](https://github.com/advisories/GHSA-jcpc-3jpw-vfhw) by replacing `commons-lang 2.6` (EOL, no upstream fix) with `commons-lang3 3.20.0`.

## Changes

`pom.xml`: Parent `50` → `51`. (No local commons-lang declaration; relied on parent's dM. lang3 is now transitively available via Spring 5.3.39 and other deps post-v51.)

Source: 6 `.java` files, sed imports `org.apache.commons.lang.` → `org.apache.commons.lang3.` (StringUtils — API-compatible).

## Test plan

- [x] `mvn clean install -Dgpg.skip=true` — green
- [ ] CI on Java 11 matrix