### PR TITLE
chore: regenerate NOTICE after parent v51 + lang3

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -20,29 +20,19 @@ This project includes:
   jQuery, jQueryUI, and the jQuery Form Plugin under the MIT license
   CK Editor under the Mozilla Public License
 
-  %systemBundle under Eclipse Public License - v 1.0
-  Aether API under Eclipse Public License, Version 1.0
-  Aether Implementation under Eclipse Public License, Version 1.0
-  Aether SPI under Eclipse Public License, Version 1.0
-  Aether Utilities under Eclipse Public License, Version 1.0
-  ant under The Apache Software License, Version 2.0
   AntLR Parser Generator under BSD License
-  AOP alliance under Public Domain
-  Apache Commons Codec under Apache License, Version 2.0
-  Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Compress under Apache License, Version 2.0
-  Apache Commons FileUpload under Apache License, Version 2.0
-  Apache Commons IO under Apache License, Version 2.0
-  Apache Commons Logging under The Apache Software License, Version 2.0
+  Apache Ant Core under The Apache Software License, Version 2.0
+  Apache Ant Launcher under The Apache Software License, Version 2.0
+  Apache Commons Codec under Apache-2.0
+  Apache Commons Collections under Apache-2.0
+  Apache Commons Compress under Apache-2.0
+  Apache Commons FileUpload under Apache-2.0
+  Apache Commons IO under Apache-2.0
+  Apache Commons Lang under Apache-2.0
+  Apache FreeMarker under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
-  Apache Maven Archiver under Apache License, Version 2.0
-  Apache Maven Filtering under Apache License, Version 2.0
-  Apache Maven Mapping under Apache License, Version 2.0
-  Apache Maven Shared Utils under Apache License, Version 2.0
-  Apache Maven WAR Plugin under Apache License, Version 2.0
   Apache Pluto Portlet Tag Library under The Apache Software License, Version 2.0
-  ASM Core under BSD
   AWS Java SDK for Amazon S3 under Apache License, Version 2.0
   AWS Java SDK for AWS KMS under Apache License, Version 2.0
   AWS SDK for Java - Core under Apache License, Version 2.0
@@ -52,34 +42,30 @@ This project includes:
   Byte Buddy (without dependencies) under Apache License, Version 2.0
   Byte Buddy agent under Apache License, Version 2.0
   c3p0 under GNU Lesser General Public License, Version 2.1 or Eclipse Public License, Version 1.0
-  CDI APIs under Apache License, Version 2.0
-  Commands under Eclipse Public License - v 1.0
-  Common Eclipse Runtime under Eclipse Public License - v 1.0
-  Commons Collections under The Apache Software License, Version 2.0
+  Checker Qual under The MIT License
+  ClassMate under Apache License, Version 2.0
   Commons Lang under The Apache Software License, Version 2.0
-  Core Hibernate O/RM functionality under GNU Lesser General Public License
-  Core Runtime under Eclipse Public License - v 1.0
-  dom4j under BSD License
-  Eclipse Content Mechanism under Eclipse Public License - v 1.0
-  Eclipse Jobs Mechanism under Eclipse Public License - v 1.0
-  Eclipse Preferences Mechanism under Eclipse Public License - v 1.0
   Ehcache Core under The Apache Software License, Version 2.0
   Ehcache Web Filters under The Apache Software License, Version 2.0
-  Equinox Application Container under Eclipse Public License - v 1.0
-  Extension Registry Support under Eclipse Public License - v 1.0
+  Error Prone shaded javac under GNU General Public License, version 2, with the Classpath Exception
+  error-prone annotations under Apache 2.0
+  Esbuild wrapper for Java bundled with original binaries under MIT License
+  FindBugs-jsr305 under The Apache Software License, Version 2.0
   fine-uploader under MIT
-  freemarker under BSD-style license
-  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  Google Java Format under The Apache Software License, Version 2.0
+  Guava InternalFutureFailureAccess and InternalFutures under The Apache Software License, Version 2.0
+  Guava ListenableFuture only under The Apache Software License, Version 2.0
+  Guava: Google Core Libraries for Java under Apache License, Version 2.0
   Hamcrest Core under New BSD License
-  Hibernate Commons Annotations under GNU Lesser General Public License
-  Hibernate JPA 2 Metamodel Generator under Apache License, Version 2.0
-  Hibernate JPA Support under GNU Lesser General Public License
+  Hibernate Commons Annotations under GNU Library General Public License v2.1 or later
+  Hibernate ORM - hibernate-c3p0 under GNU Library General Public License v2.1 or later
+  Hibernate ORM - hibernate-core under GNU Library General Public License v2.1 or later
+  Hibernate ORM - hibernate-entitymanager under GNU Library General Public License v2.1 or later
+  Hibernate ORM - hibernate-jpamodelgen under GNU Library General Public License v2.1 or later
   Hibernate Tools under GNU Lesser General Public License
-  Hibernate/c3p0 Integration under GNU Lesser General Public License
-  Hibernate/Ehcache Integration under GNU Lesser General Public License
-  HttpClient under Apache License
   HyperSQL Database under HSQLDB License, a BSD open source license
   istack common utility code runtime under Eclipse Distribution License - v 1.0
+  J2ObjC Annotations under Apache License, Version 2.0
   Jackson dataformat: CBOR under The Apache Software License, Version 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
   Jackson-core under The Apache Software License, Version 2.0
@@ -88,69 +74,47 @@ This project includes:
   Jakarta Activation API jar under EDL 1.0
   Jakarta XML Binding API under Eclipse Distribution License - v 1.0
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
-  Java Annotation Indexer under AL 2.0
-  Java Persistence API, Version 2.1 under Eclipse Public License (EPL), Version 1.0 or Eclipse Distribution License (EDL), Version 1.0
+  Java Annotation Indexer under Apache License, Version 2.0
   Java Portlet Specification V2.0 under Commons Development and Distribution License, Version 1.0
-  Java Transaction API under Commons Development and Distribution License, Version 1.0
+  Java Servlet API under CDDL + GPLv2 with classpath exception
+  Java Transaction API under Common Development and Distribution License or GNU General Public License, Version 2 with the Classpath Exception
   JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
-  Javassist under MPL 1.1 or LGPL 2.1 or Apache License 2.0
-  javax.inject under The Apache Software License, Version 2.0
+  javax.annotation API under CDDL + GPLv2 with classpath exception
+  javax.persistence-api under Eclipse Public License v1.0 or Eclipse Distribution License v. 1.0
   JAXB Runtime under Eclipse Distribution License - v 1.0
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
   JBoss Logging 3 under Apache License, version 2.0
-  JBoss Logging I18n Annotations under Public Domain
-  JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
   JMES Path Query library under Apache License, Version 2.0
-  Joda-Time under Apache 2
-  JSR-250 Common Annotations for the JavaTM Platform under COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
+  Joda-Time under Apache License, Version 2.0
   jstl under Commons Development and Distribution License, Version 1.0
-  JTidy under Java HTML Tidy License
-  JUL to SLF4J bridge under MIT License
   JUnit under Eclipse Public License 1.0
-  Log4j Implemented Over SLF4J under Apache Software Licenses
-  Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
-  Logback Core Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
-  Maven Aether Provider under The Apache Software License, Version 2.0
-  Maven Artifact under The Apache Software License, Version 2.0
-  Maven Core under The Apache Software License, Version 2.0
-  Maven Model under The Apache Software License, Version 2.0
-  Maven Model Builder under The Apache Software License, Version 2.0
-  Maven Plugin API under The Apache Software License, Version 2.0
-  Maven Repository Metadata Model under The Apache Software License, Version 2.0
-  Maven Settings under The Apache Software License, Version 2.0
-  Maven Settings Builder under The Apache Software License, Version 2.0
+  Logback Classic Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
+  Logback Core Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
   mchange-commons-java under GNU Lesser General Public License, Version 2.1 or Eclipse Public License, Version 1.0
   mockito-core under The MIT License
   Neko HTML under The Apache Software License, Version 2.0
   Objenesis under Apache License, Version 2.0
-  org.eclipse.sisu.inject under Eclipse Public License, Version 1.0
-  org.eclipse.sisu.plexus under Eclipse Public License, Version 1.0
+  Old JAXB Runtime under Eclipse Distribution License - v 1.0
   OWASP AntiSamy under BSD License
   pdfobject under MIT
-  Plexus :: Component Annotations under The Apache Software License, Version 2.0
-  Plexus Archiver Component under Apache License, Version 2.0
-  Plexus Cipher: encryption/decryption Component under Apache Public License 2.0
-  Plexus Classworlds under The Apache Software License, Version 2.0
-  Plexus Common Utilities under Apache License, Version 2.0
-  Plexus Interpolation API under Apache License, Version 2.0
-  Plexus IO Components under Apache License, Version 2.0
-  Plexus Security Dispatcher Component under Apache Public License 2.0
-  plexus-build-api under Apache Public License 2.0
+  Portlet Servlet Adapter under Apache License, Version 2.0
+  PortletMVC4Spring Framework under Apache License, Version 2.0
+  PortletMVC4Spring Security under Apache License, Version 2.0
+  Project Lombok under The MIT License
   Resource Server API under Apache License Version 2.0
   Resource Server Content under Apache License Version 2.0
   Resource Server Core under Apache License Version 2.0
   Resource Server Utilities under Apache License Version 2.0
-  servlet-api under Commons Development and Distribution License, Version 1.0
   Simple Content Management Portlet under Apache License Version 2.0
-  Sisu Guice - Core Library under The Apache Software License, Version 2.0
-  SLF4J API Module under MIT License
-  snappy under Apache License 2.0
-  software.amazon.ion:ion-java under The Apache License, Version 2.0
+  SLF4J API Module under MIT
   Spring AOP under Apache License, Version 2.0
   Spring Beans under Apache License, Version 2.0
+  Spring Commons Logging Bridge under Apache License, Version 2.0
   Spring Context under Apache License, Version 2.0
   Spring Core under Apache License, Version 2.0
+  Spring Data Core under Apache License, Version 2.0
+  Spring Data JPA under Apache License, Version 2.0
   Spring Expression Language (SpEL) under Apache License, Version 2.0
   Spring JDBC under Apache License, Version 2.0
   Spring Object/Relational Mapping under Apache License, Version 2.0
@@ -160,12 +124,9 @@ This project includes:
   Spring Web MVC under Apache License, Version 2.0
   Spring Web Portlet under Apache License, Version 2.0
   standard under Apache License, Version 2.0
-  Text under Eclipse Public License - v 1.0
   TXW2 Runtime under Eclipse Distribution License - v 1.0
-  Tycho org.eclipse.jdt.core dependency (Incubation) under Eclipse Public License
   uPortal under The Apache License, Version 2.0
   Xerces2 Java Parser under The Apache Software License, Version 2.0
-  XML Commons External Components XML APIs under The Apache Software License, Version 2.0
   XML Commons External Components XML APIs Extensions under The Apache Software License, Version 2.0
-  XZ for Java under Public Domain
+  xml-apis under The Apache Software License, Version 2.0
 


### PR DESCRIPTION
Follow-up to #545 — that PR bumped the parent to v51 and migrated commons-lang to commons-lang3, but didn't regenerate NOTICE. \`mvn notice:check\` is failing on master, which would block \`release:prepare\` for 3.4.1.

This PR runs \`mvn notice:generate\` against the post-v51 dep tree and copies the result to NOTICE. Net effect:

- Drops several Eclipse Equinox / Aether / Maven plugin shells that were transitive but unused at runtime.
- Picks up Apache Commons Lang (lang3 transitive) and Apache FreeMarker.
- License-name normalization across several entries (Apache-2.0 vs older variants).

## Test plan

- [x] \`mvn -B notice:check\` passes locally on Java 11
- [x] \`mvn -B clean install\` passes
- [ ] CI green
- [ ] Post-merge: \`mvn release:clean release:prepare release:perform\` for 3.4.1