### PR TITLE
fix: pin portletmvc4spring to 5.2.0 (last Portlet 2.0 compatible)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,13 @@
         <resource-server.version>1.5.3</resource-server.version>
         <spring.version>5.3.39</spring.version>
         <spring-data.version>2.7.18</spring-data.version>
-        <portletmvc4spring.version>5.3.4</portletmvc4spring.version>
+        <!-- portletmvc4spring 5.2.1+ calls PortletRequest.getRenderParameters(),
+             which is a JSR-362 (Portlet 3.0) API method. uPortal/Pluto provides
+             only JSR-286 (Portlet 2.0), and Apache Pluto is in the Attic with no
+             Portlet 3.0 / Jakarta path. Pin to 5.2.0 (the last Portlet-2.0-compatible
+             release). Renovate is also pinned in renovate.json so the bump can't
+             recur. -->
+        <portletmvc4spring.version>5.2.0</portletmvc4spring.version>
         <uportal-maven-plugin.version>1.0.1</uportal-maven-plugin.version>
         <uportal-libs.version>5.17.3</uportal-libs.version>
         <!-- jakarta.xml.bind-api: last 2.x on Central is 2.3.3. The 2.x line still

--- a/renovate.json
+++ b/renovate.json
@@ -28,12 +28,18 @@
         "org.springframework:spring-web",
         "org.springframework:spring-webmvc",
         "org.springframework:spring-webmvc-portlet",
-        "org.springframework.data:spring-data-jpa",
-        "com.liferay.portletmvc4spring:com.liferay.portletmvc4spring.framework",
-        "com.liferay.portletmvc4spring:com.liferay.portletmvc4spring.security"
+        "org.springframework.data:spring-data-jpa"
       ],
       "allowedVersions": "< 6.0",
       "description": "This portlet is pinned to Spring Framework 5.3.x. Next-major bumps (Spring 6+) require Jakarta EE + Java 17+, neither of which match this portlet's stack."
+    },
+    {
+      "matchPackageNames": [
+        "com.liferay.portletmvc4spring:com.liferay.portletmvc4spring.framework",
+        "com.liferay.portletmvc4spring:com.liferay.portletmvc4spring.security"
+      ],
+      "allowedVersions": "<= 5.2.0",
+      "description": "portletmvc4spring 5.2.1+ adds JSR-362 (Portlet 3.0) API calls (PortletRequest.getRenderParameters()). uPortal/Pluto runs JSR-286 (Portlet 2.0); Apache Pluto is in the Attic with no Portlet 3.0 path. 5.2.0 is the last Portlet-2.0-compatible release."
     },
     {
       "matchPackagePrefixes": [


### PR DESCRIPTION
## Problem

3.4.1 shipped \`portletmvc4spring\` 5.3.4 (via Renovate #535). Starting at **5.2.1**, portletmvc4spring's \`PortletRequestMappingHandlerAdapter.invokeHandlerMethod\` calls \`PortletRequest.getRenderParameters()\` unconditionally, which is a **JSR-362 (Portlet 3.0)** API method. uPortal/Pluto provides only JSR-286 (Portlet 2.0); [Apache Pluto is in the Attic](https://attic.apache.org/projects/portals.html) with no Portlet 3.0 / Jakarta path.

The result is that every portlet region rendered by the \`cms\` portlet fails with \`NoSuchMethodError\` — \`waffle-menu\`, \`notification-icon\`, \`feedback-navigation\`, \`legal-footer\`, \`portal-logo\`, \`attachments\`, \`logging-in\`, \`uportal-links\`. In the rendered page that shows up as *"An error occurred loading this content"* in the chrome regions, and it accounts for ~16 of the 23 Playwright smoke-test failures observed in uPortal-start after the 2026-05 fleet wave.

## How the breakpoint was identified

I bytecode-grepped \`PortletRequestMappingHandlerAdapter.class\` across portletmvc4spring 5.1.0 → 5.3.4 for references to \`getRenderParameters\`:

| version | refs |
|---|---|
| 5.1.0 | 0 |
| 5.2.0 | 0 |
| 5.2.1 | 1 |
| 5.2.2 | 1 |
| ... | ... |
| 5.3.4 | 1 |

5.2.0 is the last Portlet-2.0-compatible release. It also happens to be what \`uportal-portlet-parent\` v51 declares as its dependencyManagement default for the artifact — this PR aligns the explicit override with that default.

## Changes

- **pom.xml**: \`<portletmvc4spring.version>\` 5.3.4 → 5.2.0 with an explanatory comment naming the JSR-362 method that breaks above 5.2.0.
- **renovate.json**: split portletmvc4spring out of the broader Spring \`< 6.0\` rule into its own rule with \`allowedVersions: <= 5.2.0\` so this bump can't recur.

## Out of scope

- The broader Spring 4.3 → 5.3 / Hibernate 4.3 → 5.6 upgrade that 3.4.1 brought in stays. This PR only rolls back the one dep that introduced the Portlet 3.0 incompatibility.
- Goes alongside two other post-wave Calendar fixes tracked separately (jackson alignment + JSP \`<%\` regex escape).

## Test plan

- [x] \`mvn -B clean install notice:check license:check\` passes locally on Java 11
- [x] Built locally as \`3.4.2-SNAPSHOT\`, deployed into uPortal-start, restarted Tomcat — \`waffle-menu\`, \`notification-icon\`, \`legal-footer\` all render their soffit content correctly. \`getRenderParameters\` ClassNotFoundException is gone from the simple-cms log.
- [ ] CI green
- [ ] Post-merge: \`mvn release:clean release:prepare release:perform\` for 3.4.2