### PR TITLE
fix: drop dead logback ContextDetachingSCL listener from web.xml

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -43,9 +43,6 @@
     </listener>
     <!-- Needed to remove JMX registration and allow for classloader GC -->
     <listener>
-        <listener-class>ch.qos.logback.classic.selector.servlet.ContextDetachingSCL</listener-class>
-    </listener>
-    <listener>
         <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
     </listener>
 


### PR DESCRIPTION
## Problem

`src/main/webapp/WEB-INF/web.xml` registers `ch.qos.logback.classic.selector.servlet.ContextDetachingSCL` as a servlet context listener. That class was part of Logback's J2EE selector machinery and **was removed from Logback in 1.3.x**.

After the parent v51 wave bumped Logback to 1.5.32, the listener fails to load with `ClassNotFoundException` at context startup, taking the entire webapp down. Caught during uPortal-start smoke testing of the 2026-05 fleet release wave.

The listener also has no functional value — Logback's modern auto-cleanup handles classloader GC and JMX deregistration without needing this hook.

## Changes

- **`src/main/webapp/WEB-INF/web.xml`**: remove the `<listener>ContextDetachingSCL</listener>` block.

## Test plan

- [x] `mvn -B clean install` passes locally on Java 11
- [x] Same listener removal pattern landing across the fleet (uPortal core, Announcements, Calendar, JasigWidget, NewsReader, SimpleContent, NotificationPortlet) as a follow-up to the 2026-05 release wave
- [ ] CI green