### PR TITLE
refactor: CKEditor webjar swap + drop resource-server-content overlay

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,12 +191,6 @@
         </dependency>
         <dependency>
             <groupId>org.jasig.resourceserver</groupId>
-            <artifactId>resource-server-content</artifactId>
-            <version>${resource-server.version}</version>
-            <type>war</type>
-        </dependency>
-        <dependency>
-            <groupId>org.jasig.resourceserver</groupId>
             <artifactId>resource-server-utils</artifactId>
             <version>${resource-server.version}</version>
             <exclusions>
@@ -436,18 +430,6 @@
                 <configuration>
                     <warName>${project.artifactId}</warName>
                     <webXml>${basedir}/src/main/webapp/WEB-INF/web.xml</webXml>
-                    <overlays>
-                        <overlay>
-                            <groupId>org.jasig.resourceserver</groupId>
-                            <artifactId>resource-server-content</artifactId>
-                            <includes>
-                                <include>rs/jquery/1.10.2/</include>
-                                <include>rs/jquery/1.11.0/</include>
-                                <include>rs/jqueryui/1.10.3/</include>
-                                <include>rs/ckeditor/4.3.2/</include>
-                            </includes>
-                        </overlay>
-                    </overlays>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/webapp/WEB-INF/jsp/cms/configureContent.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/configureContent.jsp
@@ -25,7 +25,7 @@
 <%--<portlet:resourceURL var="previewUrl" id="preview" escapeXml="false"/>--%>
 
 <%-- jQuery is now provided by the portal as up.jQuery; skin.xml include removed --%>
-<script src="<rs:resourceURL value='/rs/ckeditor/4.3.2/ckeditor.js'/>" type="text/javascript"></script>
+<script src="/resource-server/webjars/ckeditor4/ckeditor.js" type="text/javascript"></script>
 
 <style type="text/css">
     #${n}contentForm { min-height: 100px; padding: 10px; margin: 10px; }
@@ -44,7 +44,6 @@
 </form:form>
 
 <script type="text/javascript">
-<rs:compressJs>
     var ${n} = ${n} || {};
         ${n}.jQuery = up.jQuery;
     ${n}.jQuery(function(){
@@ -75,5 +74,4 @@
         });
         
     });
-</rs:compressJs>
 </script>


### PR DESCRIPTION
## Summary

Two commits, both part of the broader resource-server consolidation:

1. **`d368c89`** (prior) — swap CKEditor 4.3.2 (legacy `/ResourceServingWebapp/`-served, multiple historical XSS CVEs) for the org.webjars.npm:ckeditor4:4.22.1 webjar via `/resource-server/webjars/ckeditor4/...`; drop dead `<rs:compressJs>` taglib wrappers.
2. **`5016a82`** (new) — drop the `resource-server-content` WAR overlay. The overlay was unpacking lodash 4.17.4 (4 CVEs), underscore, backbone, modernizr, normalize, and jquery-plugins into the WAR for nothing, plus an explicit maven-war-plugin extract of jquery/jqueryui/ckeditor — none of which any JSP/JS in the source references after `d368c89`.

## Test plan

- [ ] `mvn clean install -DskipTests` builds (verified locally on Java 11)
- [ ] WAR has no `rs/` directory (verified)
- [ ] Smoke: visit `/p/please-register/?pCm=config` (or any SimpleContentPortlet config view), CKEditor mounts on the textarea — covered by uPortal-start's `tests/ux/portlets/simple-content.spec.ts` and `tests/ux/smoke/visual-resource-server.spec.ts`