### PR TITLE
fix(release-script): respect Maven gpg.keyname

### DIFF
--- a/release-portlet.sh
+++ b/release-portlet.sh
@@ -99,9 +99,19 @@ grep -q '<id>central</id>' "$HOME/.m2/settings.xml" \
   || warn "<server id=central> not in settings.xml — release:perform upload may fail"
 ok "~/.m2/settings.xml present"
 
-FINGERPRINT=$(gpg --list-secret-keys --with-colons --fingerprint 2>/dev/null | awk -F: '/^fpr:/{print $10; exit}')
-[[ -n "$FINGERPRINT" ]] || fail "no GPG secret key in default keyring"
-ok "signing fingerprint: $FINGERPRINT"
+# Prefer the keyname Maven is configured to use (<gpg.keyname> in settings.xml);
+# fall back to the first secret key in the keyring if none is configured.
+GPG_KEYNAME=$(grep -oE '<gpg\.keyname>[^<]+' "$HOME/.m2/settings.xml" 2>/dev/null | head -1 | sed 's/<gpg\.keyname>//')
+if [[ -n "$GPG_KEYNAME" ]]; then
+  FINGERPRINT=$(gpg --list-keys --with-colons "$GPG_KEYNAME" 2>/dev/null | awk -F: '/^fpr:/{print $10; exit}')
+  [[ -n "$FINGERPRINT" ]] || fail "gpg.keyname=$GPG_KEYNAME from settings.xml not found in keyring"
+  ok "Maven gpg.keyname: $GPG_KEYNAME → fingerprint $FINGERPRINT"
+else
+  FINGERPRINT=$(gpg --list-secret-keys --with-colons --fingerprint 2>/dev/null | awk -F: '/^fpr:/{print $10; exit}')
+  [[ -n "$FINGERPRINT" ]] || fail "no GPG secret key in default keyring"
+  warn "no <gpg.keyname> in ~/.m2/settings.xml — falling back to first secret key"
+  ok "signing fingerprint: $FINGERPRINT"
+fi
 
 HTTP=$(curl -so /dev/null -w "%{http_code}" "https://keys.openpgp.org/vks/v1/by-fingerprint/$FINGERPRINT")
 [[ "$HTTP" == "200" ]] || fail "key $FINGERPRINT not on keys.openpgp.org (HTTP $HTTP) — upload via https://keys.openpgp.org/upload"


### PR DESCRIPTION
## Summary

- `release-portlet.sh`'s key-on-keyserver preflight was picking the first secret key in the GPG keyring instead of the one Maven actually signs with
- Read `<gpg.keyname>` from `~/.m2/settings.xml`, resolve to a fingerprint via `gpg --list-keys`, check that fingerprint on `keys.openpgp.org`; fall back to the first-key heuristic only when no keyname is configured

## Why

Caught during the SimpleContentPortlet 3.4.3 release attempt. The committer's keyring had two secret keys — a 2015 key (on `keyserver.ubuntu.com` but not on `keys.openpgp.org`) and a 2021 key (the one referenced by `<gpg.keyname>` in `~/.m2/settings.xml`, already on `keys.openpgp.org`). The script grabbed the 2015 one and falsely failed the preflight; on this machine no portlet release would succeed until this is fixed.

## Test plan

- [ ] Re-run `release-portlet.sh --release 3.4.3 --next 3.4.4-SNAPSHOT` after merge and confirm Phase 2 prints `Maven gpg.keyname: 73B71777CA7F628A → fingerprint 2943B2A0…` and proceeds past the keyserver check