### PR TITLE
chore(release-script): run notice:check + license:check in preflight

### DIFF
--- a/release-portlet.sh
+++ b/release-portlet.sh
@@ -150,16 +150,38 @@ mvn -B clean install > /tmp/release-build.log 2>&1 \
   || { echo; tail -30 /tmp/release-build.log; fail "build failed (see /tmp/release-build.log)"; }
 ok "clean install passed"
 
-# 5. Styling pass
-hdr "Styling (notice:generate / license:format / javadoc:fix)"
+# 5. Styling pass — auto-fix NOTICE/license/javadoc drift, then verify
+#    notice:check and license:check are what mvn release:prepare's `clean verify`
+#    runs; running them here surfaces drift before the destructive release plugin.
+hdr "Styling pass + NOTICE/license verification"
+
+# Run formatters/generators (best-effort; warnings only)
 mvn -B notice:generate license:format javadoc:fix > /tmp/release-styling.log 2>&1 \
   || warn "styling pass non-zero exit (see /tmp/release-styling.log)"
+
+# Verify check goals pass. If notice:check fails, target/NOTICE.expected contains
+# the correct content — copy it over and re-verify.
+if ! mvn -B notice:check license:check > /tmp/release-checks.log 2>&1; then
+  if [[ -f target/NOTICE.expected ]] && ! diff -q target/NOTICE.expected NOTICE > /dev/null 2>&1; then
+    cp target/NOTICE.expected NOTICE
+    warn "NOTICE refreshed from target/NOTICE.expected"
+    if ! mvn -B notice:check license:check > /tmp/release-checks.log 2>&1; then
+      echo; tail -30 /tmp/release-checks.log
+      fail "notice:check / license:check still failing after NOTICE auto-fix"
+    fi
+  else
+    echo; tail -30 /tmp/release-checks.log
+    fail "notice:check / license:check failed (see /tmp/release-checks.log)"
+  fi
+fi
+
+# Anything left in the working tree is drift the operator must review + commit
 if ! git diff --quiet; then
-  printf '\ndrift detected:\n'
+  printf '\ndrift detected (auto-fixed; operator must review + commit):\n'
   git diff --stat
   fail "review the diff above, commit as 'chore: pre-release prep', push to upstream/$BRANCH, then re-run this script"
 fi
-ok "no drift"
+ok "no drift; notice:check + license:check pass"
 
 # 6. Artifact discovery
 hdr "Artifact discovery"


### PR DESCRIPTION
## Summary

- Run `notice:check` and `license:check` during preflight instead of just running the formatters and trusting `git diff` to detect drift
- Auto-copy `target/NOTICE.expected` over root `NOTICE` when `notice:check` reports drift, then re-verify (matches the documented "review changes and commit" workflow)
- Preserve the operator-review-then-commit-then-rerun loop for any remaining auto-fixed working-tree changes

## Why

The 3.4.3 release (cut today via this script) hit two failure paths that the preflight should have caught but didn't:

1. **NOTICE drift**: `notice:generate` writes to `target/`, not the root `NOTICE`. After a dependency was dropped from `pom.xml` (the `resource-server-content` overlay in #554), the root `NOTICE` stayed stale, the script's `git diff` check found nothing, and the drift only surfaced when `mvn release:prepare`'s `clean verify` invoked `notice:check` mid-release.

2. **Missing license header**: `license:format` only updates files that have a header to update. `release-portlet.sh` was committed in #557 without an Apache header at all and slipped past the script's styling pass entirely. `license:check` would have caught it; the script never ran it.

Both failures cost a full `mvn release:clean` + manual prep commit + push + retry per occurrence.

## Test plan

- [ ] On a portlet repo with deliberately stale `NOTICE` (e.g. delete a known-current line), run `release-portlet.sh --release X --next Y` and confirm Phase 5 auto-syncs `target/NOTICE.expected → NOTICE` and aborts with the diff for operator review
- [ ] On a portlet repo with a file missing the Apache header, confirm Phase 5 aborts with `license:check` output rather than proceeding to the destructive release plugin