### PR TITLE
build(deps): migrate S3 attachment storage to AWS SDK v2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
     <properties>
         <!-- Dependency versions -->
-        <aws.version>1.12.797</aws.version>
+        <aws.version>2.46.7</aws.version>
         <commons-fileupload.version>1.6.0</commons-fileupload.version>
         <commons-io.version>2.22.0</commons-io.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
@@ -99,16 +99,9 @@
         </dependency>
         <!-- ===== Compile Time Dependencies ============================== -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
             <version>${aws.version}</version>
-            <exclusions>
-                <!-- aws-java-sdk-core pulls commons-logging:1.1.3 (banned; use jcl-over-slf4j). -->
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/src/main/java/org/jasig/portlet/attachment/service/AmazonS3PersistenceStrategy.java
+++ b/src/main/java/org/jasig/portlet/attachment/service/AmazonS3PersistenceStrategy.java
@@ -18,22 +18,20 @@
  */
 package org.jasig.portlet.attachment.service;
 
-import java.io.ByteArrayInputStream;
 import java.text.MessageFormat;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.xml.bind.DatatypeConverter;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Base64;
 import org.jasig.portlet.attachment.model.Attachment;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 /**
  * Persistence strategy which persists the attachment's file to an S3 bucket
@@ -72,31 +70,40 @@ public class AmazonS3PersistenceStrategy implements IDocumentPersistenceStrategy
             return null;
         }
 
-        AmazonS3 s3 = AmazonS3ClientBuilder.defaultClient();
-
         String key = PATH_FORMAT.format(new Object[]{s3BucketPath, attachment.getGuid(), attachment.getFilename()});
 
-        ObjectMetadata metadata = new ObjectMetadata();
-        metadata.setContentType(attachment.getContentType());
-        metadata.setContentLength(attachment.getData().length);
-        metadata.setCacheControl(s3CacheControlString);
-
         // S3 chose base64-encoded hash not the typical 32-character hex string so convert accordingly.
-        // Hex.decodeHex(attachment.getChecksum().toCharArray())
-        metadata.setContentMD5(Base64.encodeBase64String(DatatypeConverter.parseHexBinary(attachment.getChecksum())));
+        String contentMd5 = Base64.encodeBase64String(DatatypeConverter.parseHexBinary(attachment.getChecksum()));
 
-        try {
-            s3.putObject(new PutObjectRequest(s3BucketName, key,
-                    new ByteArrayInputStream(attachment.getData()), metadata));
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(s3BucketName)
+                .key(key)
+                .contentType(attachment.getContentType())
+                .contentLength((long) attachment.getData().length)
+                .cacheControl(s3CacheControlString)
+                .contentMD5(contentMd5)
+                .build();
+
+        // v2 S3Client holds a connection pool and is AutoCloseable, so close it per use.
+        try (S3Client s3 = buildS3Client()) {
+            s3.putObject(putObjectRequest, RequestBody.fromBytes(attachment.getData()));
             log.debug("Successfully sent {} to S3 bucket {} under key {}", attachment.getFilename(),
                     s3BucketName, key);
-        } catch (AmazonClientException e) {
+        } catch (SdkException e) {
             String message = String.format("Unable to persist attachment %1s to S3 bucket %2s, key %3s",
                     attachment.getFilename(), s3BucketName, key);
             throw new PersistenceException(message, e);
         }
 
         return (s3BucketBaseUrl.endsWith("/")? s3BucketBaseUrl : s3BucketBaseUrl + "/") + key;
+    }
+
+    /**
+     * Builds an S3 client using the default region and credentials provider chains.
+     * Visible for testing so the client can be replaced with a mock.
+     */
+    protected S3Client buildS3Client() {
+        return S3Client.create();
     }
 
 

--- a/src/test/java/org/jasig/portlet/attachment/service/AmazonS3PersistenceStrategyTest.java
+++ b/src/test/java/org/jasig/portlet/attachment/service/AmazonS3PersistenceStrategyTest.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portlet.attachment.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.nio.charset.StandardCharsets;
+import org.jasig.portlet.attachment.model.Attachment;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+public class AmazonS3PersistenceStrategyTest {
+
+    @Test
+    public void persistsAttachmentWithExpectedKeyAndMetadata() {
+        final S3Client mockClient = mock(S3Client.class);
+        AmazonS3PersistenceStrategy strategy =
+                new AmazonS3PersistenceStrategy() {
+                    @Override
+                    protected S3Client buildS3Client() {
+                        return mockClient;
+                    }
+                };
+        strategy.setS3BucketName("my-bucket");
+        strategy.setS3BucketBaseUrl("https://cdn.example.edu");
+        strategy.setS3BucketPath("portlets/attachments");
+        strategy.setS3CacheControlString("private, max-age=2592000");
+
+        Attachment attachment = new Attachment();
+        attachment.setGuid("abc-123");
+        attachment.setFilename("file.txt");
+        attachment.setContentType("text/plain");
+        attachment.setData("hello".getBytes(StandardCharsets.UTF_8));
+        attachment.setChecksum("5d41402abc4b2a76b9719d911017c592"); // md5("hello")
+
+        String url = strategy.persistAttachmentBinary(null, attachment);
+
+        ArgumentCaptor<PutObjectRequest> captor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(mockClient).putObject(captor.capture(), any(RequestBody.class));
+
+        PutObjectRequest request = captor.getValue();
+        assertEquals("my-bucket", request.bucket());
+        assertEquals("portlets/attachments/abc-123/file.txt", request.key());
+        assertEquals("text/plain", request.contentType());
+        assertEquals("private, max-age=2592000", request.cacheControl());
+        assertEquals(Long.valueOf(5L), request.contentLength());
+
+        assertEquals(
+                "https://cdn.example.edu/portlets/attachments/abc-123/file.txt", url);
+
+        // The v2 client is AutoCloseable; try-with-resources must close it.
+        verify(mockClient).close();
+    }
+}


### PR DESCRIPTION
Problem: SimpleContentPortlet depends on AWS SDK v1 (`com.amazonaws:aws-java-sdk-s3` 1.12.797), which AWS has placed **out of security support** — deployers are receiving AWS end-of-support warning emails (reported by Jeff Dake).

Goal: move the S3 attachment persistence strategy to the supported AWS SDK v2, with no change to stored object layout or returned URLs.

Changes:
- `pom.xml`: replace `com.amazonaws:aws-java-sdk-s3` with `software.amazon.awssdk:s3`, set `<aws.version>` to `2.46.7`; drop the commons-logging exclusion (v2 uses `apache5-client` → `httpclient5` → slf4j, so commons-logging is no longer pulled — verified via `dependency:tree`).
- `AmazonS3PersistenceStrategy`: rebuild the `putObject` call on the v2 builder API (`PutObjectRequest.builder` + `RequestBody.fromBytes`); wrap the client in **try-with-resources** since v2 `S3Client` is `AutoCloseable` and holds a connection pool; extract `buildS3Client()` as a test seam.
- add `AmazonS3PersistenceStrategyTest` (Mockito) asserting the request is built with the expected bucket/key/metadata and that the client is closed.

Verification: `mvn test` green; `dependency:tree` confirms a sync HTTP client (`apache5-client`) is present and commons-logging is absent.

⚠️ **Deployer-facing behavior change:** v2 resolves region strictly via the default chain (`AWS_REGION` / profile / instance metadata) and fails fast if none is set, whereas v1 sometimes defaulted to `us-east-1`. **S3-backed deployers may need to set a region explicitly.** Deployers using the default DB persistence are unaffected — the S3 client is only built when the S3 strategy is actually used.

No automated test exercises a live bucket; the test mocks `S3Client`.